### PR TITLE
Add graceful handling of a student not existing

### DIFF
--- a/grading/__main__.py
+++ b/grading/__main__.py
@@ -13,6 +13,7 @@ from getpass import getpass
 
 from ruamel.yaml import YAML
 
+import github3 as gh3
 from github3 import authorize
 
 from . import ok
@@ -205,6 +206,18 @@ def distribute():
     else:
         for student in config['students']:
             print("Fetching work for %s..." % student)
+
+            try:
+                GH.check_student_repo_exists(config['organisation'],
+                                             config['courseName'],
+                                             student,
+                                             token=config['github']['token'])
+            except gh3.exceptions.NotFoundError as e:
+                print("Student {} does not have a repository for this "
+                      "course, maybe they have not accepted the invitation "
+                      "yet? Skipping them for now.".format(student))
+                continue
+
             with tempfile.TemporaryDirectory() as d:
                 student_dir = GH.fetch_student(config['organisation'],
                                                config['courseName'],

--- a/grading/github.py
+++ b/grading/github.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import random
 import string
 import subprocess
@@ -6,6 +7,31 @@ import subprocess
 import github3 as gh3
 
 from .utils import _call_git
+
+
+def check_student_repo_exists(org, course, student, token=None):
+    """Check if the student has a repository for the course.
+
+    It happens that students delete their repository or do not accept the
+    invitation to the course. In either case they will not have a repository
+    yet.
+    """
+    # temporarily change log level of github3.py as it prints weird messages
+    # XXX could be done more nicely with a context manager maybe
+    gh3_log = logging.getLogger('github3')
+    old_level = gh3_log.level
+    gh3_log.setLevel('ERROR')
+
+    try:
+        g = gh3.login(token=token)
+        repository = "{}-{}".format(course, student)
+        g.repository(org, repository)
+
+    except Exception as e:
+        raise e
+
+    finally:
+        gh3_log.setLevel(old_level)
 
 
 def fetch_student(org, course, student, directory, token=None):


### PR DESCRIPTION
When distributing work a student's repository can not (yet) exist and we
need to give a nice error message in that case.

closes #16 