### PR TITLE
Close outstanding PRs whe ndistributing new material

### DIFF
--- a/grading/__main__.py
+++ b/grading/__main__.py
@@ -44,9 +44,9 @@ def init():
     while not password:
         password = getpass('Password for {0}: '.format(user))
 
-    note = 'grading workflow helper'
-    note_url = 'http://example.com'
-    scopes = ['repo']
+    note = 'Grading workflow helper'
+    note_url = 'https://github.com/earthlab/grading-workflow-experiments'
+    scopes = ['repo', 'read:user']
 
     def two_factor():
         code = ''
@@ -218,6 +218,11 @@ def distribute():
                       "yet? Skipping them for now.".format(student))
                 continue
 
+            repo = "{}-{}".format(config['courseName'], student)
+            GH.close_existing_pullrequests(config['organisation'],
+                                           repo,
+                                           token=config['github']['token'])
+
             with tempfile.TemporaryDirectory() as d:
                 student_dir = GH.fetch_student(config['organisation'],
                                                config['courseName'],
@@ -228,7 +233,6 @@ def distribute():
                 copytree(P('student'), student_dir)
 
                 if GH.repo_changed(student_dir):
-                    repo = "{}-{}".format(config['courseName'], student)
                     message = 'New material for next week.'
                     branch = GH.new_branch(student_dir)
 

--- a/grading/github.py
+++ b/grading/github.py
@@ -64,6 +64,26 @@ def fetch_student(org, course, student, directory, token=None):
     return os.path.join(directory, "{}-{}".format(course, student))
 
 
+def close_existing_pullrequests(org, repository, branch_base='new-material-',
+                                token=None):
+    """Close all oustanding course material update Pull Requests
+
+    If there are any PRs open in a student's repository that originate from
+    a branch starting with `branch_base` as name and created by the user
+    we are logged in we close them.
+    """
+    g = gh3.login(token=token)
+    me = g.me()
+    repo = g.repository(org, repository)
+    for pr in repo.pull_requests(state='open'):
+        origin = pr.head.label
+        origin_repo, origin_branch = origin.split(':')
+        if origin_branch.startswith(branch_base) and pr.user == me:
+            pr.comment("Closed in favor of a new Pull Request to bring you "
+                       "up-to-date.")
+            pr.close()
+
+
 def create_pr(org, repository, branch, title, token):
     """Create a Pull Request with changes from branch"""
     msg = ("Merge this Pull Request to get the material for the next "


### PR DESCRIPTION
When we distribute new material to students close outstanding PRs that
were delivering new material as we will only end up with merge conflicts
if students try to merge these old PRs once we have made a new one.