### PR TITLE
Add handling of the case when the template repo exists

### DIFF
--- a/grading/__main__.py
+++ b/grading/__main__.py
@@ -195,10 +195,15 @@ def distribute():
             copytree(P('student'), d)
             GH.git_init(d)
             GH.commit_all_changes(d, "Initial commit")
-            GH.create_repo(config['organisation'],
-                           repo_name,
-                           d,
-                           config['github']['token'])
+            try:
+                GH.create_repo(config['organisation'],
+                               repo_name,
+                               d,
+                               config['github']['token'])
+            except gh3.exceptions.UnprocessableEntity as e:
+                print(e.msg)
+                print("This is probably because the template repository "
+                      "already exists.")
 
         print('Visit https://github.com/{}/{}'.format(config['organisation'],
                                                       repo_name))


### PR DESCRIPTION
This will print a nice message when the template repository already exists instead of crashing.

Closes #15 