### PR TITLE
Updates to fix bug in nbdistribute where students who haven't accepted the invite yet fail

### DIFF
--- a/grading/github.py
+++ b/grading/github.py
@@ -27,8 +27,14 @@ def check_student_repo_exists(org, course, student, token=None):
         repository = "{}-{}".format(course, student)
         g.repository(org, repository)
 
-    except Exception as e:
-        raise e
+    except gh3.exceptions.NotFoundError as e:
+        print("Student {} does not have a repository for this "
+              "course, maybe they have not accepted the invitation "
+              "yet? Skipping them for now.".format(student))
+    # As written this it not capturing the right exception so it's simply failing
+    # Should this "continue" even if it fails on a student?
+    #except Exception as e:
+    #    raise e
 
     finally:
         gh3_log.setLevel(old_level)


### PR DESCRIPTION
Addresses [this issue](https://github.com/earthlab/grading-workflow-experiments/issues/22)

@betatim will you kindly look at this and tell me if i'm on the correct tract. Essentially what i tracked down is you had a test in the `distribute` function to check for a missing student. BUT it looks like the function in the github module actually was where the exception was happening and that just looked for a standard exception.

I *think* this works locally now... but also have a few questions

1. when i run nbinit, it fails ofcourse UNLESS i recreate the token (delete it manually from my gh account)
2. if i dont run nbinit it seems like sometimes gh is unhappy with my token. 

See my PR addressing the nbinit issues. i'm not clear whether we still have to authenticate in that init call regardless of the token creation.

I don't think i know enough yet to fully understand how tokens are being created and used to make sense of this but it seems we need to adjust nbinit. For instance, does that have to be run every time and then you delete the old one and create the new token??

Note that in this PR i commented out your code. i was wondering if you want to run "continue" in that for loop or not? i'll happily clean up the code just want to understand if i'm on the right track here. 

I also have a  stupid question for you about running this package locally and testing things when you have local imports. i'm doing a lot of stuff manually to test and would love your guidance.